### PR TITLE
Initial Prototype ZarrReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # ZarrReader
+
+Requires custom jzarr: https://github.com/dgault/jzarr/tree/ome-zarr
+Requires Bio-Formats update to add reader: https://github.com/ome/bioformats/pull/3639
+
+Known Issues/TODO list:
+- Currently working on packaging, discovered issue when connecting to S3 using packaged jar
+- S3 File System Store is likely not ideal sceanrio, other options to be investigated
+- S3 access currently very inefficient
+- Odd issue with data being lost when decompressing bytes in jzarr, an ugly hack is currently in place
+- Identification of S3 location needs updating
+- Refactor code to remove duplication
+- Parse colours for labels

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ZarrReader
 
 Requires custom jzarr: https://github.com/dgault/jzarr/tree/ome-zarr
+
 Requires Bio-Formats update to add reader: https://github.com/ome/bioformats/pull/3639
 
 Known Issues/TODO list:

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <dependency>
       <groupId>com.bc.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.3-SNAPSHOT</version>
+      <version>0.3.2</version>
+      <!-- <version>0.4-SNAPSHOT</version>-->
     </dependency>
     
 <!--     <dependency> -->
@@ -81,7 +82,7 @@
 <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-api</artifactId>
-      <version>6.6.0-SNAPSHOT</version>
+      <version>6.6.1-SNAPSHOT</version>
     </dependency>
     
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
 
 <!--   </build> -->
   <build>
+    <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,7 @@
   </pluginRepositories>
   
   <dependencies>
-    <dependency>
-      <groupId>ome</groupId>
-      <artifactId>formats-gpl</artifactId>
-      <version>6.6.0-SNAPSHOT</version>
-    </dependency>
+
     
 <!--     <dependency> -->
 <!--       <groupId>org.blosc</groupId> -->
@@ -50,32 +46,44 @@
       <version>0.3-SNAPSHOT</version>
     </dependency>
     
-    <dependency>
-    <groupId>org.lasersonlab</groupId>
-    <artifactId>s3fs</artifactId>
-    <version>2.2.3</version>
-</dependency>
+<!--     <dependency> -->
+<!--     <groupId>org.lasersonlab</groupId> -->
+<!--     <artifactId>s3fs</artifactId> -->
+<!--     <version>2.2.3</version> -->
+<!-- </dependency> -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
       <version>2.13.8</version>
     </dependency>
-        <dependency>
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>netty-nio-client</artifactId>
       <version>2.13.8</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.13.8</version>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>bom</artifactId>
       <version>2.11.10</version>
       <type>pom</type>
     </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>sts</artifactId>
-      <version>2.13.8</version>
+        <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.8.0</version>
     </dependency>
+<dependency>
+      <groupId>ome</groupId>
+      <artifactId>formats-api</artifactId>
+      <version>6.6.0-SNAPSHOT</version>
+    </dependency>
+    
   </dependencies>
   
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,154 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ome</groupId>
+  <artifactId>zarrReader</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
+      <id>ome</id>
+      <name>OME Artifactory</name>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
+    </repository>
+    <repository>
+      <id>bc-nexus-repo</id>
+      <name>Brockmann-Consult Public Maven Repository</name>
+      <url>http://nexus.senbox.net/nexus/content/groups/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
+  
+  <dependencies>
+    <dependency>
+      <groupId>ome</groupId>
+      <artifactId>formats-gpl</artifactId>
+      <version>6.6.0-SNAPSHOT</version>
+    </dependency>
+    
+<!--     <dependency> -->
+<!--       <groupId>org.blosc</groupId> -->
+<!--       <artifactId>jblosc</artifactId> -->
+<!--       <version>1.0.1</version> -->
+<!--     </dependency> -->
+        
+    <dependency>
+      <groupId>com.bc.zarr</groupId>
+      <artifactId>jzarr</artifactId>
+      <version>0.3-SNAPSHOT</version>
+    </dependency>
+    
+    <dependency>
+    <groupId>org.lasersonlab</groupId>
+    <artifactId>s3fs</artifactId>
+    <version>2.2.3</version>
+</dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>2.13.8</version>
+    </dependency>
+        <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>netty-nio-client</artifactId>
+      <version>2.13.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bom</artifactId>
+      <version>2.11.10</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.13.8</version>
+    </dependency>
+  </dependencies>
+  
+    <properties>
+    <project.rootdir>${basedir}/../..</project.rootdir>
+    <maven.compiler.source>1.8</maven.compiler.source>
+   <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+<!--   <build> -->
+<!--   <sourceDirectory>${project.basedir}/src</sourceDirectory> -->
+<!--     <resources> -->
+<!--     <resource> -->
+<!--       <directory>${project.basedir}/src</directory> -->
+<!--       <excludes> -->
+<!--         <exclude>**/*.java</exclude> -->
+<!--         <exclude>**/package.html</exclude> -->
+<!--         <exclude>**/*.properties</exclude> -->
+<!--       </excludes> -->
+<!--     </resource> -->
+<!--     <resource> -->
+<!--       <directory>${project.basedir}/src</directory> -->
+<!--       <includes> -->
+<!--         <include>**/*.properties</include> -->
+<!--       </includes> -->
+<!--       <filtering>true</filtering> -->
+<!--     </resource> -->
+<!--     <resource> -->
+<!--       <directory>${project.basedir}</directory> -->
+<!--       <includes> -->
+<!--         <include>**/*.cpp</include> -->
+<!--       </includes> -->
+<!--       <filtering>true</filtering> -->
+<!--     </resource> -->
+<!--     </resources> -->
+
+<!--   </build> -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <appendAssemblyId>false</appendAssemblyId>
+
+          <archive>
+            <manifest>
+              <mainClass>loci.formats.in.ZarrReader</mainClass>
+              <addClasspath>true</addClasspath>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Date>${maven.build.timestamp}</Implementation-Date>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
+          </archive>
+          <descriptorRefs>
+          <descriptorRef>jar-with-dependencies</descriptorRef>
+        </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ome</groupId>
   <artifactId>zarrReader</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.1</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>ome</groupId>
-  <artifactId>zarrReader</artifactId>
+  <artifactId>OMEZarrReader</artifactId>
   <version>0.0.1</version>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
       <name>Brockmann-Consult Public Maven Repository</name>
       <url>http://nexus.senbox.net/nexus/content/groups/public/</url>
     </repository>
+    <repository>
+      <id>glencoe-jzarr</id>
+      <name>Glencoe Software JZarr Repository </name>
+      <url>https://repo.glencoesoftware.com/repository/jzarr-snapshots/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -43,7 +48,7 @@
     <dependency>
       <groupId>com.bc.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.3.2</version>
+      <version>0.3.3-gs-SNAPSHOT</version>
       <!-- <version>0.4-SNAPSHOT</version>-->
     </dependency>
     

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -32,10 +32,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3FileSystemStore implements Store {
 
     private Path root;
     S3Client client;
+    protected static final Logger LOGGER =
+        LoggerFactory.getLogger(S3FileSystemStore.class);
 
     public S3FileSystemStore(String path, FileSystem fileSystem) {
         if (fileSystem == null) {
@@ -99,6 +104,7 @@ public class S3FileSystemStore implements Store {
           return responseStream;
         } catch (Exception e) {
           // TODO Auto-generated catch block
+          LOGGER.info( "Unable to locate or access key: " + key2);
           e.printStackTrace();
         }
 

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -1,5 +1,6 @@
 package loci.formats;
 
+//import com.amazonaws.ClientConfiguration;
 import com.bc.zarr.ZarrConstants;
 import com.bc.zarr.ZarrUtils;
 import com.bc.zarr.storage.Store;
@@ -59,7 +60,7 @@ public class S3FileSystemStore implements Store {
         String key2 = root.toString().substring(root.toString().indexOf(pathSplit[3]), root.toString().length()) + File.separator + key;
 
         URI endpoint_uri;
-        try {
+        try {   
           endpoint_uri = new URI(endpoint);
           final S3Configuration config = S3Configuration.builder()
             .pathStyleAccessEnabled(true)
@@ -79,7 +80,7 @@ public class S3FileSystemStore implements Store {
           e.printStackTrace();
         } catch (Exception e) {
           // TODO Auto-generated catch block
-          e.printStackTrace();
+          //e.printStackTrace();
         }  
       }
       return null;

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -99,7 +99,7 @@ public class S3FileSystemStore implements Store {
           return responseStream;
         } catch (Exception e) {
           // TODO Auto-generated catch block
-          //e.printStackTrace();
+          e.printStackTrace();
         }
 
       return null;

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -1,0 +1,178 @@
+package loci.formats;
+
+
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.util.IOUtils;
+import com.bc.zarr.ZarrConstants;
+import com.bc.zarr.ZarrUtils;
+import com.bc.zarr.storage.Store;
+
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class S3FileSystemStore implements Store {
+
+    private Path root;
+
+    public S3FileSystemStore(String path, FileSystem fileSystem) {
+        if (fileSystem == null) {
+            root = Paths.get(path);
+        } else {
+            root = fileSystem.getPath(path);
+        }
+    }
+
+    public S3FileSystemStore(Path rootPath) {
+        root = rootPath;
+    }
+
+    @Override
+    public InputStream getInputStream(String key) throws IOException {
+        final Path path = root.resolve(key);
+        if (Files.isReadable(path)) {
+            return Files.newInputStream(path);
+        } else {
+        
+        String[] pathSplit = root.toString().split(File.separator);
+        String endpoint = "https://" + pathSplit[1] + File.separator;
+        String bucketName =  pathSplit[2];
+        String key2 = root.toString().substring(root.toString().indexOf(pathSplit[3]), root.toString().length()) + File.separator + key;
+
+        URI endpoint_uri;
+        try {
+          endpoint_uri = new URI(endpoint);
+          final S3Configuration config = S3Configuration.builder()
+            .pathStyleAccessEnabled(true)
+            .build();
+          AwsCredentials credentials = AnonymousCredentialsProvider.create().resolveCredentials();
+          S3Client client = S3Client.builder()
+            .endpointOverride(endpoint_uri)
+            .serviceConfiguration(config)
+            .region(Region.EU_WEST_1) // Ignored but required by the client
+            .credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
+          GetObjectRequest getRequest = GetObjectRequest.builder().bucket(bucketName).key(key2).build();
+          ResponseInputStream<GetObjectResponse> responseStream = client.getObject(getRequest, ResponseTransformer.toInputStream());
+        
+          //TODO: Test if can be removed 
+//          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+//          IOUtils.copy(responseStream, outputStream);
+//          byte[] array = outputStream.toByteArray();
+       
+          responseStream = client.getObject(getRequest, ResponseTransformer.toInputStream());
+          return responseStream;
+        } catch (URISyntaxException e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        } catch (Exception e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        }  
+      }
+      return null;
+    }
+
+    @Override
+    public OutputStream getOutputStream(String key) throws IOException {
+        final Path filePath = root.resolve(key);
+        final Path dir = filePath.getParent();
+        Files.createDirectories(dir);
+        return Files.newOutputStream(filePath);
+    }
+
+    @Override
+    public void delete(String key) throws IOException {
+        final Path toBeDeleted = root.resolve(key);
+        if (Files.isDirectory(toBeDeleted)) {
+            ZarrUtils.deleteDirectoryTreeRecursively(toBeDeleted);
+        }
+        if (Files.exists(toBeDeleted)){
+            Files.delete(toBeDeleted);
+        }
+        if (Files.exists(toBeDeleted)|| Files.isDirectory(toBeDeleted)) {
+            throw new IOException("Unable to initialize " + toBeDeleted.toAbsolutePath().toString());
+        }
+    }
+
+    @Override
+    public TreeSet<String> getArrayKeys() throws IOException {
+        return getKeysFor(ZarrConstants.FILENAME_DOT_ZARRAY);
+    }
+
+    @Override
+    public TreeSet<String> getGroupKeys() throws IOException {
+        return getKeysFor(ZarrConstants.FILENAME_DOT_ZGROUP);
+    }
+
+    private TreeSet<String> getKeysFor(String suffix) throws IOException {
+      TreeSet<String> keys = new TreeSet<String>();
+      
+      String[] pathSplit = root.toString().split(File.separator);
+      
+      String endpoint = "https://" + pathSplit[1] + File.separator;
+      String bucketName =  pathSplit[2];
+      String key2 = root.toString().substring(root.toString().indexOf(pathSplit[3]), root.toString().length());
+  
+      //TODO: Reused connection code
+      URI endpoint_uri;
+      try {
+        endpoint_uri = new URI(endpoint);
+  
+        final S3Configuration config = S3Configuration.builder()
+          .pathStyleAccessEnabled(true)
+          .build();
+        AwsCredentials credentials = AnonymousCredentialsProvider.create().resolveCredentials();
+        S3Client client = S3Client.builder()
+          .endpointOverride(endpoint_uri)
+          .serviceConfiguration(config)
+          .region(Region.EU_WEST_1) // Ignored but required by the client
+          .credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
+        List<S3Object> list = client.listObjects(ListObjectsRequest.builder()
+          .bucket(bucketName)
+          .prefix(key2)
+          .build()).contents();
+        int n = list.size();
+
+        for (int i = 0; i < n; i++) {
+          S3Object object = list.get(i);
+          String k = object.key();
+          if (k.contains(suffix)) {
+            String key = k.substring(k.indexOf(key2) + key2.length() + 1, k.indexOf(suffix));
+            if (!key.isEmpty()) {
+              keys.add(key.substring(0, key.length()-1));
+            }
+          }
+        }
+      } catch (URISyntaxException e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
+      return keys;
+    }
+}

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -1,8 +1,5 @@
 package loci.formats;
 
-
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.util.IOUtils;
 import com.bc.zarr.ZarrConstants;
 import com.bc.zarr.ZarrUtils;
 import com.bc.zarr.storage.Store;
@@ -11,8 +8,6 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -22,7 +17,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class S3FileSystemStore implements Store {
 
@@ -79,12 +72,6 @@ public class S3FileSystemStore implements Store {
             .credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
           GetObjectRequest getRequest = GetObjectRequest.builder().bucket(bucketName).key(key2).build();
           ResponseInputStream<GetObjectResponse> responseStream = client.getObject(getRequest, ResponseTransformer.toInputStream());
-        
-          //TODO: Test if can be removed 
-//          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-//          IOUtils.copy(responseStream, outputStream);
-//          byte[] array = outputStream.toByteArray();
-       
           responseStream = client.getObject(getRequest, ResponseTransformer.toInputStream());
           return responseStream;
         } catch (URISyntaxException e) {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -27,7 +27,10 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +38,7 @@ import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import org.apache.commons.io.FileUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -419,6 +423,23 @@ public class ZarrReader extends FormatReader {
         resSeries.put(resCounts.size() - 1, list);
       }
     }
+  }
+  
+  /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
+  @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+    String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr") + 5);
+    ArrayList<String> usedFiles = new ArrayList<String>();
+    usedFiles.add(zarrRootPath);
+    File folder = new File(zarrRootPath);
+    Collection<File> libs = FileUtils.listFiles(folder, null, true);
+    for (File file : libs) {
+      usedFiles.add(file.getAbsolutePath());
+  }
+    String[] fileArr = new String[usedFiles.size()];
+    fileArr = usedFiles.toArray(fileArr);
+    return fileArr;
   }
 
 }

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -426,20 +426,20 @@ public class ZarrReader extends FormatReader {
   }
   
   /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
-  @Override
-  public String[] getUsedFiles(boolean noPixels) {
-    FormatTools.assertId(currentId, true, 1);
-    String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr") + 5);
-    ArrayList<String> usedFiles = new ArrayList<String>();
-    usedFiles.add(zarrRootPath);
-    File folder = new File(zarrRootPath);
-    Collection<File> libs = FileUtils.listFiles(folder, null, true);
-    for (File file : libs) {
-      usedFiles.add(file.getAbsolutePath());
-  }
-    String[] fileArr = new String[usedFiles.size()];
-    fileArr = usedFiles.toArray(fileArr);
-    return fileArr;
-  }
+//  @Override
+//  public String[] getUsedFiles(boolean noPixels) {
+//    FormatTools.assertId(currentId, true, 1);
+//    String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr") + 5);
+//    ArrayList<String> usedFiles = new ArrayList<String>();
+//    usedFiles.add(zarrRootPath);
+//    File folder = new File(zarrRootPath);
+//    Collection<File> libs = FileUtils.listFiles(folder, null, true);
+//    for (File file : libs) {
+//      usedFiles.add(file.getAbsolutePath());
+//  }
+//    String[] fileArr = new String[usedFiles.size()];
+//    fileArr = usedFiles.toArray(fileArr);
+//    return fileArr;
+//  }
 
 }

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -436,7 +436,6 @@ public class ZarrReader extends FormatReader {
       Collection<File> libs = FileUtils.listFiles(folder, null, true);
       for (File file : libs) {
         usedFiles.add(file.getAbsolutePath());
-        System.out.println(file.getAbsolutePath());
       }
     }
     else {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -1,0 +1,424 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2020 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import com.bc.zarr.ZarrUtils;
+
+import loci.common.DataTools;
+import loci.common.Location;
+import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.MissingLibraryException;
+import loci.formats.SubResolutionFormatReader;
+import loci.formats.meta.MetadataStore;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.JZarrServiceImpl;
+import ome.xml.meta.MetadataConverter;
+import loci.formats.services.OMEXMLService;
+import loci.formats.services.ZarrService;
+
+
+public class ZarrReader extends FormatReader {
+
+  private transient ZarrService zarrService;
+  private ArrayList<String> arrayPaths;
+  private HashMap<Integer, ArrayList<String>> resSeries = new HashMap<Integer, ArrayList<String>>();
+  private HashMap<String, Integer> resCounts = new HashMap<String, Integer>();
+  private HashMap<String, Integer> resIndexes = new HashMap<String, Integer>();
+  
+  public ZarrReader() {
+    super("Zarr", "zarr");
+    suffixSufficient = false;
+    domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+  }
+  
+  /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
+  @Override
+  public boolean isThisType(String name, boolean open) {
+    Location zarrFolder = new Location(name).getParentFile();
+    // if (zarrFolder != null && zarrFolder.exists() && zarrFolder.getAbsolutePath().indexOf(".zarr") > 0) {
+    if (zarrFolder != null && zarrFolder.getAbsolutePath().indexOf(".zarr") > 0) {
+      return true;
+    }
+    return super.isThisType(name, open);
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    return zarrService.getChunkSize()[1];
+  }
+  
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    return zarrService.getChunkSize()[0];
+  }
+  
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
+    final MetadataStore store = makeFilterMetadata();
+    Location zarrFolder = new Location( id ).getParentFile();
+    String zarrPath = zarrFolder.getAbsolutePath();
+    String zarrRootPath = zarrPath.substring(0, zarrPath.indexOf(".zarr") + 5);
+    String name = zarrRootPath.substring(zarrRootPath.lastIndexOf(File.separator)+1, zarrRootPath.length() - 5);
+    Location omeMetaFile = new Location( zarrRootPath, name+".ome.xml" );
+    
+    initializeZarrService(zarrPath);
+    
+    /*
+     * Open OME metadata file
+     * TODO: Old code to either be reworked with writer or removed entirely
+     */
+    if (omeMetaFile.exists()) {
+      Document omeDocument = null;
+      try (RandomAccessInputStream measurement =
+          new RandomAccessInputStream(omeMetaFile.getAbsolutePath())) {
+        try {
+          omeDocument = XMLTools.parseDOM(measurement);
+        }
+        catch (ParserConfigurationException e) {
+          throw new IOException(e);
+        }
+        catch (SAXException e) {
+          throw new IOException(e);
+        }
+      }
+      omeDocument.getDocumentElement().normalize();
+      
+      OMEXMLService service = null;
+      String xml = null;
+      try
+      {
+        xml = XMLTools.getXML( omeDocument );
+      }
+      catch (TransformerException e2 )
+      {
+        LOGGER.debug( "", e2 );
+      }
+      OMEXMLMetadata omexmlMeta = null;
+      try
+      {
+        service = new ServiceFactory().getInstance( OMEXMLService.class );
+        omexmlMeta = service.createOMEXMLMetadata( xml );
+      }
+      catch (DependencyException | ServiceException | NullPointerException e1 )
+      {
+        LOGGER.debug( "", e1 );
+      }
+  
+      int numDatasets = omexmlMeta.getImageCount();
+  
+      int oldSeries = getSeries();
+      core.clear();
+      for (int i=0; i<numDatasets; i++) {
+        CoreMetadata ms = new CoreMetadata();
+        core.add(ms);
+  
+        setSeries(i);
+  
+        Integer w = omexmlMeta.getPixelsSizeX(i).getValue();
+        Integer h = omexmlMeta.getPixelsSizeY(i).getValue();
+        Integer t = omexmlMeta.getPixelsSizeT(i).getValue();
+        Integer z = omexmlMeta.getPixelsSizeZ(i).getValue();
+        Integer c = omexmlMeta.getPixelsSizeC(i).getValue();
+        if (w == null || h == null || t == null || z == null | c == null) {
+          throw new FormatException("Image dimensions not found");
+        }
+  
+        Boolean endian = null;
+        String pixType = omexmlMeta.getPixelsType(i).toString();
+        ms.dimensionOrder = omexmlMeta.getPixelsDimensionOrder(i).toString();
+        ms.sizeX = w.intValue();
+        ms.sizeY = h.intValue();
+        ms.sizeT = t.intValue();
+        ms.sizeZ = z.intValue();
+        ms.sizeC = c.intValue();
+        ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
+        ms.littleEndian = endian == null ? false : !endian.booleanValue();
+        ms.rgb = false;
+        ms.interleaved = false;
+        ms.indexed = false;
+        ms.falseColor = true;
+        ms.pixelType = FormatTools.pixelTypeFromString(pixType);
+        ms.orderCertain = true;
+        if (omexmlMeta.getPixelsSignificantBits(i) != null) {
+          ms.bitsPerPixel = omexmlMeta.getPixelsSignificantBits(i).getValue();
+        }
+      }
+      setSeries(oldSeries);
+      MetadataConverter.convertMetadata( omexmlMeta, store );
+    }
+    else {
+
+      // Parse base level attributes
+      Map<String, Object> attr = zarrService.getGroupAttr(zarrRootPath);
+      int attrIndex = 0;
+      if (attr != null && !attr.isEmpty()) {
+        parseResolutionCount(zarrRootPath, "");
+        String jsonAttr = ZarrUtils.toJson(attr, true);
+        store.setXMLAnnotationValue(jsonAttr, attrIndex);
+        String xml_id = MetadataTools.createLSID("AttributesAnnotation:", attrIndex); 
+        store.setXMLAnnotationID(xml_id, attrIndex);
+      }
+      
+      // Parse group attributes
+      for (String key: zarrService.getGroupKeys(zarrRootPath)) {
+        Map<String, Object> attributes = zarrService.getGroupAttr(zarrRootPath+File.separator+key);
+        if (attributes != null && !attributes.isEmpty()) {
+          parseResolutionCount(zarrRootPath, key);
+          attrIndex++;
+          String jsonAttr = ZarrUtils.toJson(attributes, true);
+          store.setXMLAnnotationValue(jsonAttr, attrIndex);
+          String xml_id = MetadataTools.createLSID("AttributesAnnotation:"+key, attrIndex); 
+          store.setXMLAnnotationID(xml_id, attrIndex);
+        }
+      }
+      
+      // Parse array attributes
+      for (String key: zarrService.getArrayKeys(zarrRootPath)) {
+        Map<String, Object> attributes = zarrService.getArrayAttr(zarrRootPath+File.separator+key);
+        if (attributes != null && !attributes.isEmpty()) {
+          attrIndex++;
+          String jsonAttr = ZarrUtils.toJson(attributes, true);
+          store.setXMLAnnotationValue(jsonAttr, attrIndex);
+          String xml_id = MetadataTools.createLSID("AttributesAnnotation:"+key, attrIndex); 
+          store.setXMLAnnotationID(xml_id, attrIndex);
+        }
+      }
+
+      arrayPaths = new ArrayList<String>();
+      arrayPaths.addAll(zarrService.getArrayKeys(zarrRootPath));
+      
+      orderArrayPaths(zarrRootPath);
+      
+      core.clear();
+      int resolutionTotal = 0;
+      for (int i=0; i<arrayPaths.size(); i++) {
+        int resolutionCount = 1;
+        if (resCounts.get(zarrRootPath+File.separator+arrayPaths.get(i)) != null) {
+          resolutionCount = resCounts.get(zarrRootPath+File.separator+arrayPaths.get(i));
+        }
+        int resolutionIndex= 0;
+        if (resIndexes.get(zarrRootPath+File.separator+arrayPaths.get(i)) != null) {
+          resolutionIndex = resIndexes.get(zarrRootPath+File.separator+arrayPaths.get(i));
+        }
+        
+        CoreMetadata ms = new CoreMetadata();
+        core.add(ms);
+    
+        if (hasFlattenedResolutions()) {
+          setSeries(i);
+        }
+        else {
+          setSeries(coreIndexToSeries(i));
+          setResolution(resolutionIndex);
+          if (i == resolutionTotal + resolutionCount - 1) {
+            resolutionTotal += resolutionCount;
+          }
+        }
+        
+        ms.pixelType = zarrService.getPixelType();
+        int[] shape = zarrService.getShape();
+        
+        ms.sizeX = shape[4];
+        ms.sizeY = shape[3];
+        ms.sizeT = shape[0];
+        ms.sizeZ = shape[2];
+        ms.sizeC = shape[1];
+        ms.dimensionOrder = "XYCZT";
+        ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
+        ms.littleEndian = zarrService.isLittleEndian();
+        ms.rgb = false;
+        ms.interleaved = false;
+        ms.resolutionCount = resolutionCount;
+      }
+    }
+    MetadataTools.populatePixels( store, this, true );
+
+  }
+
+  /* @see loci.formats.FormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    try {
+      initializeZarrService(currentId);
+    }
+    catch (FormatException e) {
+      throw new IOException(e);
+    }
+  }
+
+  // -- Helper methods --
+
+  private void initializeZarrService(String id) throws IOException, FormatException {
+//    try {
+//      ServiceFactory factory = new ServiceFactory();
+//      zarrService = factory.getInstance(ZarrService.class);
+//      zarrService.open(id);
+//    } catch (DependencyException e) {
+//      throw new MissingLibraryException(ZarrServiceImpl.NO_ZARR_MSG, e);
+//    }
+    zarrService = new JZarrServiceImpl();
+    openZarr();
+  }
+  
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h) throws FormatException, IOException {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    int[] coordinates = getZCTCoords(no);
+    int [] shape = {1, 1, 1, h, w};
+    int [] offsets = {coordinates[2], coordinates[1], coordinates[0], y, x};
+    Object image = zarrService.readBytes(shape, offsets);
+
+    boolean little = zarrService.isLittleEndian();
+    int bpp = FormatTools.getBytesPerPixel(zarrService.getPixelType());
+    if (image instanceof byte[]) {
+      buf = (byte []) image;
+    }
+    else if (image instanceof short[]) {
+      short[] data = (short[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 2 * i, 2, little);
+        }
+      }
+    }
+    else if (image instanceof int[]) {
+      int[] data = (int[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 4 * i, 4, little);
+        }
+      }
+    }
+    else if (image instanceof float[]) {
+      float[] data = (float[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          int value = Float.floatToIntBits(data[(row * w) + i + x]);
+          DataTools.unpackBytes(value, buf, base + 4 * i, 4, little);
+        }
+      }
+    }
+    else if (image instanceof double[]) {
+      double[] data = (double[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          long value = Double.doubleToLongBits(data[(row * w) + i + x]);
+          DataTools.unpackBytes(value, buf, base + 8 * i, 8, little);
+        }
+      }
+    }
+    return buf;
+  }
+  
+  @Override
+  public void setSeries(int no) {
+    super.setSeries(no);
+    openZarr();
+  }
+  
+  private void openZarr() {
+    try {
+      if (currentId != null && zarrService != null) {
+        String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr")+5);
+        String newZarrPath = zarrRootPath;
+        if (arrayPaths != null) {
+          newZarrPath += File.separator + arrayPaths.get(series);
+          zarrService.open(newZarrPath);
+        }
+      }
+    } catch (IOException | FormatException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+  }
+  
+  private void orderArrayPaths(String root) {
+    for (int i = 0; i < resSeries.size(); i++) {
+      for (String arrayPath: resSeries.get(i)) {
+        arrayPaths.remove(arrayPath);
+      }
+      for (String arrayPath: resSeries.get(i)) {
+        arrayPaths.add(arrayPath);
+      }
+    }
+  }
+  
+  private void parseResolutionCount(String root, String key) throws IOException, FormatException {
+    String path = key.isEmpty() ? root : root + File.separator + key;
+    Map<String, Object> attr = zarrService.getGroupAttr(path);
+    ArrayList<Object> multiscales = (ArrayList<Object>) attr.get("multiscales");
+    if (multiscales != null) {
+      Map<String, Object> datasets = (Map<String, Object>) multiscales.get(0);
+      ArrayList<Object> multiscalePaths = (ArrayList<Object>)datasets.get("datasets");
+      resSeries.put(resCounts.size(), new ArrayList<String>());
+      for (int i = 0; i < multiscalePaths.size(); i++) {
+        Map<String, Object> multiScale = (Map<String, Object>) multiscalePaths.get(i);
+        String scalePath = (String) multiScale.get("path");
+        int numRes = multiscalePaths.size();
+        if (i == 0) {
+          resCounts.put(path+File.separator+scalePath, numRes);
+        }
+        resIndexes.put(path+File.separator+scalePath, i);
+        ArrayList<String> list = resSeries.get(resCounts.size() - 1);
+        list.add(key.isEmpty() ? scalePath : key + File.separator + scalePath);
+        resSeries.put(resCounts.size() - 1, list);
+      }
+    }
+  }
+
+}

--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -1,0 +1,317 @@
+package loci.formats.services;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteOrder;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.Set;
+
+import com.bc.zarr.ArrayParams;
+import com.bc.zarr.Compressor;
+import com.bc.zarr.CompressorFactory;
+import com.bc.zarr.DataType;
+import com.bc.zarr.ZarrArray;
+import com.bc.zarr.ZarrGroup;
+
+import loci.common.services.AbstractService;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.S3FileSystemStore;
+import loci.formats.meta.IPyramidStore;
+import loci.formats.meta.MetadataRetrieve;
+import ucar.ma2.InvalidRangeException;
+
+public class JZarrServiceImpl extends AbstractService
+implements ZarrService  {
+  // -- Constants --
+  public static final String NO_ZARR_MSG = "JZARR is required to read Zarr files.";
+
+  // -- Fields --
+  ZarrArray zarrArray;
+  String currentId;
+  Compressor zlibComp = CompressorFactory.create("zlib", 8);  // 8 = compression level .. valid values 0 .. 9
+  Compressor nullComp = CompressorFactory.create("null", 0);
+  
+  /**
+   * Default constructor.
+   */
+  public JZarrServiceImpl() {
+      checkClassDependency(com.bc.zarr.ZarrArray.class);
+  }
+  
+  @Override
+  public void open(String file) throws IOException, FormatException {
+    currentId = file;
+    // TODO: Update s3 location identification
+    if (!file.toLowerCase().contains("s3:")) {
+    zarrArray = ZarrArray.open(file);
+    }
+    else {
+      zarrArray = ZarrArray.open(new S3FileSystemStore(Paths.get(file)));
+    }
+  }
+  
+  public Map<String, Object> getGroupAttr(String path) throws IOException, FormatException {
+    ZarrGroup group = null;
+    if (!path.toLowerCase().contains("s3:")) {
+      group = ZarrGroup.open(path);
+    }
+    else {
+      group = ZarrGroup.open(new S3FileSystemStore(Paths.get(path)));
+    }
+    return group.getAttributes();
+  }
+  
+  public Map<String, Object> getArrayAttr(String path) throws IOException, FormatException {
+    ZarrArray array = null;
+    if (!path.toLowerCase().contains("s3:")) {
+      array = ZarrArray.open(path);
+    }
+    else {
+      array = ZarrArray.open(new S3FileSystemStore(Paths.get(path)));
+    }
+    return array.getAttributes();
+  }
+  
+  public Set<String> getGroupKeys(String path) throws IOException, FormatException {
+    ZarrGroup group = null;
+    if (!path.toLowerCase().contains("s3:")) {
+      group = ZarrGroup.open(path);
+    }
+    else {
+      group = ZarrGroup.open(new S3FileSystemStore(Paths.get(path)));
+    }
+    return group.getGroupKeys();
+  }
+  
+  public Set<String> getArrayKeys(String path) throws IOException, FormatException {
+    ZarrGroup group = null;
+    if (!path.toLowerCase().contains("s3:")) {
+      group = ZarrGroup.open(path);
+    }
+    else {
+      group = ZarrGroup.open(new S3FileSystemStore(Paths.get(path)));
+    }
+    return group.getArrayKeys();
+  }
+
+  private DataType getZarrPixelType(int pixType) {
+    DataType pixelType = null;
+      switch(pixType) {
+        case FormatTools.INT8:
+          pixelType = DataType.i1;
+          break;
+        case FormatTools.INT16:
+          pixelType = DataType.i2;
+          break;
+        case FormatTools.INT32:
+          pixelType = DataType.i4;
+          break;
+        case FormatTools.UINT8:
+          pixelType = DataType.u1;
+          break;
+        case FormatTools.UINT16:
+          pixelType = DataType.u2;
+          break;
+        case FormatTools.UINT32:
+          pixelType = DataType.u4;
+          break;
+        case FormatTools.FLOAT:
+          pixelType = DataType.f4;
+          break;
+        case FormatTools.DOUBLE:
+          pixelType = DataType.f8;
+          break;
+      }
+      return(pixelType);
+  }
+  
+  private int getOMEPixelType(DataType pixType) {
+    int pixelType = -1;
+      switch(pixType) {
+        case i1:
+          pixelType = FormatTools.INT8;
+          break;
+        case i2:
+          pixelType = FormatTools.INT16;
+          break;
+        case i4:
+          pixelType = FormatTools.INT32;
+          break;
+        case u1:
+          pixelType = FormatTools.UINT8;
+          break;
+        case u2:
+          pixelType = FormatTools.UINT16;
+          break;
+        case u4:
+          pixelType = FormatTools.UINT32;
+          break;
+        case f4:
+          pixelType = FormatTools.FLOAT;
+          break;
+        case f8:
+          pixelType = FormatTools.DOUBLE;
+          break;
+        case i8:
+          pixelType = FormatTools.DOUBLE;
+          break;
+      default:
+        break;
+      }
+      return(pixelType);
+  }
+
+  @Override
+  public String getNoZarrMsg() {
+    return NO_ZARR_MSG;
+  }
+
+  @Override
+  public int[] getShape() {
+    if (zarrArray != null) return zarrArray.getShape();
+    return null;
+  }
+
+  @Override
+  public int[] getChunkSize() {
+    if (zarrArray != null) return zarrArray.getChunks();
+    return null;
+  }
+
+  @Override
+  public int getPixelType() {
+    if (zarrArray != null) return getOMEPixelType(zarrArray.getDataType());
+    return 0;
+  }
+  
+  @Override
+  public boolean isLittleEndian() {
+    if (zarrArray != null) return (zarrArray.getByteOrder() == ByteOrder.LITTLE_ENDIAN);
+    return false;
+  }
+
+  @Override
+  public void close() throws IOException {
+    zarrArray = null;
+    currentId = null;
+  }
+  
+  @Override
+  public boolean isOpen() throws IOException {
+    return (zarrArray != null && currentId != null);
+  }
+  
+  @Override
+  public String getID() throws IOException {
+    return currentId;
+  }
+
+  @Override
+  public Object readBytes(int[] shape, int[] offset) throws FormatException, IOException {
+    if (zarrArray != null) {
+      try {
+        return zarrArray.read(shape, offset);
+      } catch (InvalidRangeException e) {
+        throw new FormatException(e);
+      }
+    }
+    else throw new IOException("No Zarr file opened");
+  }
+
+  @Override
+  public void saveBytes(Object data, int[] shape, int[] offset) throws FormatException, IOException {
+    if (zarrArray != null) {
+      try {
+        zarrArray.write(data, shape, offset);
+      } catch (InvalidRangeException e) {
+        throw new FormatException(e);
+      }
+    }
+    else throw new IOException("No Zarr file opened");
+  }
+
+  @Override
+  public void create(String file, MetadataRetrieve meta, int[] chunks, Compression compression) throws IOException {
+    int seriesCount = meta.getImageCount();
+    int resolutionCount = 1;
+    
+    ArrayParams params = new ArrayParams();
+    params.chunks(chunks);
+    params.compressor(nullComp);
+    
+    boolean isLittleEndian = !meta.getPixelsBigEndian(0);
+    if (isLittleEndian) {
+      params.byteOrder(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    int x = meta.getPixelsSizeX(0).getValue().intValue();
+    int y = meta.getPixelsSizeY(0).getValue().intValue();
+    int z = meta.getPixelsSizeZ(0).getValue().intValue();
+    int c = meta.getPixelsSizeC(0).getValue().intValue();
+    int t = meta.getPixelsSizeT(0).getValue().intValue();
+   // c /= meta.getChannelSamplesPerPixel(0, 0).getValue().intValue();
+    int [] shape = {x, y, z, c, t};
+    params.shape(shape);
+    
+    int pixelType = FormatTools.pixelTypeFromString(meta.getPixelsType(0).toString());
+    DataType zarrPixelType = getZarrPixelType(pixelType);
+    int bytes = FormatTools.getBytesPerPixel(pixelType);
+    params.dataType(zarrPixelType);
+
+    if (seriesCount > 1) {
+      ZarrGroup root = ZarrGroup.create(file);
+      ZarrGroup currentGroup = root;
+      for (int i = 0; i < seriesCount; i++) {
+        x = meta.getPixelsSizeX(i).getValue().intValue();
+        y = meta.getPixelsSizeY(i).getValue().intValue();
+        z = meta.getPixelsSizeZ(i).getValue().intValue();
+        c = meta.getPixelsSizeC(i).getValue().intValue();
+        t = meta.getPixelsSizeT(i).getValue().intValue();
+      //  c /= meta.getChannelSamplesPerPixel(i, 0).getValue().intValue();
+        shape = new int[]{x, y, z, c, t};
+        params.shape(shape);
+        
+        pixelType = FormatTools.pixelTypeFromString(meta.getPixelsType(i).toString());
+        zarrPixelType = getZarrPixelType(pixelType);
+        params.dataType(zarrPixelType);
+        
+        isLittleEndian = !meta.getPixelsBigEndian(i);
+        if (isLittleEndian) {
+          params.byteOrder(ByteOrder.LITTLE_ENDIAN);
+        }
+        
+        if (meta instanceof IPyramidStore) {
+          resolutionCount = ((IPyramidStore) meta).getResolutionCount(i);
+        }
+        if (resolutionCount > 1) {
+          currentGroup = root.createSubGroup("Series"+i);
+          for (int j = 0; j < resolutionCount; j++) {
+            zarrArray = currentGroup.createArray("Resolution"+j, params);
+          }  
+        }
+        else { 
+          zarrArray = currentGroup.createArray("Series"+i, params);
+        }
+      }
+    }
+    else {
+      zarrArray = ZarrArray.create(file, params);
+    }
+
+    currentId = file;
+  }
+  
+  @Override
+  public void create(String id, MetadataRetrieve meta, int[] chunks) throws IOException {
+    create(id, meta, chunks, Compression.NONE);
+  }
+
+  
+}

--- a/src/loci/formats/services/ZarrService.java
+++ b/src/loci/formats/services/ZarrService.java
@@ -1,0 +1,83 @@
+package loci.formats.services;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import loci.common.services.Service;
+import loci.formats.FormatException;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.services.ZarrService.Compression;
+
+public interface ZarrService extends Service {
+  
+  enum Compression {
+    NONE,
+    ZLIB
+  }
+  
+
+  /**
+   * Gets the text string for when Zarr implementation has not been found.
+   */
+  public String getNoZarrMsg();
+
+  /**
+   * Gets shape of Zarr as an array of dimensions.
+   * @return  shape.
+   */
+  public int [] getShape();
+
+  /**
+   * Gets the chunk size as an array of dimensions.
+   * @return  chunk size.
+   */
+  public int [] getChunkSize();
+
+  /**
+   * Gets the image pixel type.
+   * @return                    pixel type.
+   */
+  public int getPixelType();
+
+  /**
+   * Closes the file.
+   */
+  public void close() throws IOException;
+
+  /**
+  * Reads values from the Zarr Array
+  * @return     Buffer of bytes read.
+  * @param      shape           int array representing the shape of each dimension
+  * @param      offset          buffer for bytes.
+  */
+  public Object readBytes(int [] shape, int [] offset) throws FormatException, IOException;
+
+  /**
+  * Writes values to the Zarr Array
+  * @param      buf            values to be written in a one dimensional array
+  * @param      shape           int array representing the shape of each dimension
+  * @param      x               the offset for each dimension
+  */
+  void saveBytes(Object data, int[] shape, int[] offset) throws FormatException, IOException;
+
+  public void open(String file) throws IOException, FormatException;
+
+  boolean isLittleEndian();
+
+  boolean isOpen() throws IOException;
+
+  String getID() throws IOException;
+
+  public void create(String id, MetadataRetrieve meta, int[] chunks) throws IOException;
+
+  void create(String id, MetadataRetrieve meta, int[] chunks, Compression compression) throws IOException;
+
+  public Map<String, Object> getGroupAttr(String path) throws IOException, FormatException;
+  
+  public Map<String, Object> getArrayAttr(String path) throws IOException, FormatException;
+  
+  public Set<String> getGroupKeys(String path) throws IOException, FormatException;
+  
+  public Set<String> getArrayKeys(String path) throws IOException, FormatException;
+}


### PR DESCRIPTION
Initial commits for 0.0.1 ZarrReader to be used as an external reader with Bio-Formats
Any application using Bio-Formats 6.6.0 onwards should be able to use the ZarrReader as an external reader.

The initial reader should be compatible with the latest OME Zarr spec including nested structure.

Note: To update the name of the reader to OMEZarrReader will require a bump to formats-api readers.txt